### PR TITLE
Configurable YouTube Data API poll interval

### DIFF
--- a/Sources/LiveStreamTally/Views/SettingsView.swift
+++ b/Sources/LiveStreamTally/Views/SettingsView.swift
@@ -164,10 +164,28 @@ struct SettingsView: View {
                         }
                         
                         // Description for both intervals
-                        HStack(spacing: 0) {
-                            Text("Note: Lower values use more YouTube API quota")
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("YouTube API Quota Information:")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                                .fontWeight(.medium)
+                            
+                            Text("• Each check when live uses 1 quota unit")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            
+                            Text("• Each check when not live uses 2 quota units")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            
+                            Text("• Default quota limit is 10,000 units per day")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            
+                            Text("Lower values mean more frequent checks but higher quota usage.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 2)
                         }
                     }
                     .padding(.vertical, 8)
@@ -216,7 +234,7 @@ struct SettingsView: View {
             .padding(16)
             .background(Color(NSColor.controlBackgroundColor))
         }
-        .frame(width: 400, height: 580)
+        .frame(width: 400, height: 650)
         .preferredColorScheme(.dark)
     }
 }

--- a/Sources/LiveStreamTally/Views/SettingsView.swift
+++ b/Sources/LiveStreamTally/Views/SettingsView.swift
@@ -21,6 +21,8 @@ struct SettingsView: View {
     // Use state for the form inputs
     @State private var channelId: String
     @State private var apiKey: String
+    @State private var liveCheckInterval: Double
+    @State private var notLiveCheckInterval: Double
     
     // Track if we're currently processing
     @State private var isProcessing = false
@@ -29,6 +31,8 @@ struct SettingsView: View {
         // Initialize form fields from PreferencesManager
         _channelId = State(initialValue: PreferencesManager.shared.getChannelId())
         _apiKey = State(initialValue: PreferencesManager.shared.getApiKey() ?? "")
+        _liveCheckInterval = State(initialValue: PreferencesManager.shared.getLiveCheckInterval())
+        _notLiveCheckInterval = State(initialValue: PreferencesManager.shared.getNotLiveCheckInterval())
         
         // Create the settings view model without creating a new MainViewModel
         // The MainViewModel will be provided by the environment
@@ -124,9 +128,64 @@ struct SettingsView: View {
                         .foregroundStyle(.primary)
                         .padding(.bottom, 8)
                 }
+                
+                Section {
+                    VStack(alignment: .leading, spacing: 24) {
+                        // Live Check Interval
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("When Live (seconds)")
+                                .foregroundStyle(.secondary)
+                            
+                            HStack {
+                                Slider(value: $liveCheckInterval, in: 10...300, step: 5)
+                                    .frame(maxWidth: .infinity)
+                                    .onChange(of: liveCheckInterval) { newValue in
+                                        viewModel.liveCheckInterval = newValue
+                                    }
+                                
+                                Text("\(Int(liveCheckInterval))")
+                                    .frame(width: 40, alignment: .trailing)
+                                    .foregroundStyle(.secondary)
+                            }
+                            
+                            Text("How often to check stream status while live")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        
+                        // Not Live Check Interval
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("When Not Live (seconds)")
+                                .foregroundStyle(.secondary)
+                            
+                            HStack {
+                                Slider(value: $notLiveCheckInterval, in: 10...300, step: 5)
+                                    .frame(maxWidth: .infinity)
+                                    .onChange(of: notLiveCheckInterval) { newValue in
+                                        viewModel.notLiveCheckInterval = newValue
+                                    }
+                                
+                                Text("\(Int(notLiveCheckInterval))")
+                                    .frame(width: 40, alignment: .trailing)
+                                    .foregroundStyle(.secondary)
+                            }
+                            
+                            Text("How often to check if you've gone live")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 8)
+                } header: {
+                    Text("Polling Intervals")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.primary)
+                        .padding(.bottom, 8)
+                }
             }
             .formStyle(.grouped)
-            .scrollDisabled(true)
+            .scrollDisabled(false)  // Allow scrolling now that we have more content
             
             // Bottom button area
             HStack {
@@ -162,7 +221,7 @@ struct SettingsView: View {
             .padding(16)
             .background(Color(NSColor.controlBackgroundColor))
         }
-        .frame(width: 440, height: 340)  // Increased height to accommodate new elements
+        .frame(width: 440, height: 480)  // Increased height to accommodate new elements
         .preferredColorScheme(.dark)
     }
 }

--- a/Sources/LiveStreamTally/Views/SettingsView.swift
+++ b/Sources/LiveStreamTally/Views/SettingsView.swift
@@ -43,7 +43,7 @@ struct SettingsView: View {
         VStack(spacing: 0) {
             Form {
                 Section {
-                    VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 16) {
                         VStack(alignment: .leading, spacing: 8) {
                             HStack {
                                 Text("API Key")
@@ -83,7 +83,7 @@ struct SettingsView: View {
                             
                             Link("How to get a YouTube API key", destination: URL(string: "https://developers.google.com/youtube/v3/getting-started")!)
                                 .font(.caption)
-                                .padding(.top, 4)
+                                .padding(.top, 2)
                         }
                         
                         VStack(alignment: .leading, spacing: 8) {
@@ -117,7 +117,7 @@ struct SettingsView: View {
                             
                             Link("How to find your YouTube Channel ID", destination: URL(string: "https://support.google.com/youtube/answer/3250431")!)
                                 .font(.caption)
-                                .padding(.top, 4)
+                                .padding(.top, 2)
                         }
                     }
                     .padding(.vertical, 8)
@@ -130,47 +130,42 @@ struct SettingsView: View {
                 }
                 
                 Section {
-                    VStack(alignment: .leading, spacing: 24) {
-                        // Live Check Interval
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("When Live (seconds)")
-                                .foregroundStyle(.secondary)
-                            
+                    VStack(alignment: .leading, spacing: 16) {
+                        // Live Check Interval (more compact version)
+                        VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Slider(value: $liveCheckInterval, in: 10...300, step: 5)
-                                    .frame(maxWidth: .infinity)
-                                    .onChange(of: liveCheckInterval) { newValue in
-                                        viewModel.liveCheckInterval = newValue
-                                    }
-                                
+                                Text("When Live (seconds)")
+                                    .foregroundStyle(.secondary)
+                                Spacer()
                                 Text("\(Int(liveCheckInterval))")
-                                    .frame(width: 40, alignment: .trailing)
                                     .foregroundStyle(.secondary)
                             }
                             
-                            Text("How often to check stream status while live")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            Slider(value: $liveCheckInterval, in: 5...300, step: 5)
+                                .onChange(of: liveCheckInterval) { newValue in
+                                    viewModel.liveCheckInterval = newValue
+                                }
                         }
                         
-                        // Not Live Check Interval
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("When Not Live (seconds)")
-                                .foregroundStyle(.secondary)
-                            
+                        // Not Live Check Interval (more compact version)
+                        VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Slider(value: $notLiveCheckInterval, in: 10...300, step: 5)
-                                    .frame(maxWidth: .infinity)
-                                    .onChange(of: notLiveCheckInterval) { newValue in
-                                        viewModel.notLiveCheckInterval = newValue
-                                    }
-                                
+                                Text("When Not Live (seconds)")
+                                    .foregroundStyle(.secondary)
+                                Spacer()
                                 Text("\(Int(notLiveCheckInterval))")
-                                    .frame(width: 40, alignment: .trailing)
                                     .foregroundStyle(.secondary)
                             }
                             
-                            Text("How often to check if you've gone live")
+                            Slider(value: $notLiveCheckInterval, in: 5...300, step: 5)
+                                .onChange(of: notLiveCheckInterval) { newValue in
+                                    viewModel.notLiveCheckInterval = newValue
+                                }
+                        }
+                        
+                        // Description for both intervals
+                        HStack(spacing: 0) {
+                            Text("Note: Lower values use more YouTube API quota")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -185,7 +180,7 @@ struct SettingsView: View {
                 }
             }
             .formStyle(.grouped)
-            .scrollDisabled(false)  // Allow scrolling now that we have more content
+            .scrollDisabled(false)  // Keep scrolling enabled to handle variable content height
             
             // Bottom button area
             HStack {
@@ -221,7 +216,7 @@ struct SettingsView: View {
             .padding(16)
             .background(Color(NSColor.controlBackgroundColor))
         }
-        .frame(width: 440, height: 480)  // Increased height to accommodate new elements
+        .frame(width: 400, height: 580)
         .preferredColorScheme(.dark)
     }
 }

--- a/Tests/LiveStreamTallyTests/Mocks.swift
+++ b/Tests/LiveStreamTallyTests/Mocks.swift
@@ -104,7 +104,8 @@ class MockPreferencesManager {
     var cachedChannelId = ""
     var uploadPlaylistId = ""
     var apiKey = ""
-    var refreshInterval: TimeInterval = 60.0
+    var liveRefreshInterval: TimeInterval = 30.0
+    var notLiveRefreshInterval: TimeInterval = 60.0
     var ndiOutputName = "LiveStreamTally"
     var ndiEnabled = false
     
@@ -126,12 +127,18 @@ class MockPreferencesManager {
         NotificationCenter.default.post(name: PreferencesManager.Notifications.apiKeyChanged, object: nil)
     }
     
-    func getRefreshInterval() -> TimeInterval {
-        return refreshInterval
+    func getLiveCheckInterval() -> TimeInterval {
+        return liveRefreshInterval
     }
     
-    func setRefreshInterval(_ value: TimeInterval) {
-        refreshInterval = value
+    func getNotLiveCheckInterval() -> TimeInterval {
+        return notLiveRefreshInterval
+    }
+    
+    func updateIntervals(liveInterval: TimeInterval, notLiveInterval: TimeInterval) {
+        liveRefreshInterval = liveInterval
+        notLiveRefreshInterval = notLiveInterval
+        NotificationCenter.default.post(name: PreferencesManager.Notifications.intervalChanged, object: nil)
     }
     
     func getNDIOutputName() -> String {

--- a/Tests/LiveStreamTallyTests/PreferencesManagerTests.swift
+++ b/Tests/LiveStreamTallyTests/PreferencesManagerTests.swift
@@ -17,7 +17,8 @@ struct PreferencesManagerTestsSuite {
         defaults.removeObject(forKey: "youtube_channel_id")
         defaults.removeObject(forKey: "youtube_channel_id_cached")
         defaults.removeObject(forKey: "youtube_upload_playlist_id")
-        defaults.removeObject(forKey: "refresh_interval")
+        defaults.removeObject(forKey: "youtube_live_check_interval")
+        defaults.removeObject(forKey: "youtube_not_live_check_interval")
         defaults.removeObject(forKey: "ndi_output_name")
         defaults.removeObject(forKey: "ndi_enabled")
     }
@@ -33,8 +34,32 @@ struct PreferencesManagerTestsSuite {
         let preferences = PreferencesManager.shared
         // Test something specific about the preferences
         #expect(preferences.getChannelId().isEmpty, "Channel ID should be empty after clearing preferences")
+        #expect(preferences.getLiveCheckInterval() == 30.0, "Live check interval should default to 30 seconds")
+        #expect(preferences.getNotLiveCheckInterval() == 60.0, "Not live check interval should default to 60 seconds")
         
         // Clean up afterwards
+        clearPreferences()
+    }
+    
+    @Test("Should update and retrieve polling intervals")
+    @MainActor func testPollingIntervals() async {
+        // Clear preferences first
+        clearPreferences()
+        
+        let preferences = PreferencesManager.shared
+        
+        // Test default values
+        #expect(preferences.getLiveCheckInterval() == 30.0, "Live check interval should default to 30 seconds")
+        #expect(preferences.getNotLiveCheckInterval() == 60.0, "Not live check interval should default to 60 seconds")
+        
+        // Update intervals
+        preferences.updateIntervals(liveInterval: 45.0, notLiveInterval: 90.0)
+        
+        // Verify updated values
+        #expect(preferences.getLiveCheckInterval() == 45.0, "Live check interval should be updated to 45 seconds")
+        #expect(preferences.getNotLiveCheckInterval() == 90.0, "Not live check interval should be updated to 90 seconds")
+        
+        // Clean up
         clearPreferences()
     }
     


### PR DESCRIPTION
Users can configure how often to poll the YouTube API for broadcast updates
There are two polling intervals - when not live and when live. Live checks use one quota unit while checks when not live use two.