### PR TITLE
Fix: Ensure Main Window Appears Reliably on Startup (Especially as Login Item)

### DIFF
--- a/Sources/LiveStreamTally/Views/ContentView.swift
+++ b/Sources/LiveStreamTally/Views/ContentView.swift
@@ -16,7 +16,8 @@ struct ContentView: View {
     @EnvironmentObject private var ndiViewModel: NDIViewModel
     private let baseWidth: CGFloat = 1280
     private let baseHeight: CGFloat = 720
-   
+    @State private var ndiObserver: NSObjectProtocol? // Store observer reference
+
     private func startMonitoring() async {
         await viewModel.startMonitoring()
     }
@@ -55,18 +56,23 @@ struct ContentView: View {
         }
         .aspectRatio(16/9, contentMode: .fit)
         .onAppear {
-            Task {
+            Task { @MainActor in
+                Logger.debug("ContentView onAppear", category: .app)
+                
+                // NDI setup/start is now handled by AppDelegate after window creation
+                
+                // Start YouTube monitoring
                 await startMonitoring()
-            }
-            DispatchQueue.main.async {
-                ndiViewModel.startStreaming()
             }
         }
         .onDisappear {
+            // Remove notification observer if it exists
+            if let observer = ndiObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
             Task {
                 await stopMonitoring()
             }
-            ndiViewModel.stopStreaming()
         }
     }
     


### PR DESCRIPTION
Problem:
When LiveStreamTally was configured as a macOS Login Item, the application would launch in the background upon user login, but its main window would not become visible until the user manually clicked the app's icon in the Dock or switched to it via Command+Tab. The desired behavior is for the main window to appear automatically once the app finishes launching.
Solution:
This PR addresses the startup visibility issue by implementing manual window management within the AppDelegate instead of relying solely on the default SwiftUI WindowGroup lifecycle for window presentation.
Manual Window Creation in AppDelegate:
The primary responsibility for creating, configuring, and showing the main application window was moved to the AppDelegate's applicationDidFinishLaunching(_:) method.
An NSWindow is created programmatically.
The root SwiftUI view (ContentView) is instantiated, injected with its necessary environment objects (MainViewModel, NDIViewModel), and wrapped in an NSHostingView.
This NSHostingView is set as the contentView of the manually created NSWindow.
Window Configuration & Display:
The NSWindow is configured with its title, initial size, resizability constraints, aspect ratio, and delegate (AppDelegate itself).
A MainWindowController is used to manage the window, and its showWindow(nil) method is called to display it.
window.makeKeyAndOrderFront(nil) is called to ensure the window becomes the key window and is brought to the front.
NSApplication.shared.activate(ignoringOtherApps: true) is called to activate the application, bringing it to the foreground.
NDI Initialization Timing:
NDI setup (ndiViewModel.setupWithMainViewModel) and streaming start (ndiViewModel.startStreaming()) are now initiated within AppDelegate.applicationDidFinishLaunching after the window has been successfully created and configured. This ensures the necessary view models and UI context are ready before NDI operations begin.
Delegate Responsibilities:
The AppDelegate is assigned as the NSWindowDelegate to handle events like windowWillClose, where NDI streaming is now stopped.
applicationShouldHandleReopen is implemented to correctly show the window if the app is clicked while already running but potentially hidden.
applicationShouldTerminateAfterLastWindowClosed is set to true for standard application termination behavior.
View Model Access:
The MainViewModel and NDIViewModel instances, created in LiveStreamTallyApp.init, are passed to the AppDelegate instance for use during window and NDI setup.
Why this works:
Manually controlling the window creation and presentation sequence within AppDelegate provides a more explicit and reliable way to ensure the window is displayed and the application is activated, bypassing potential timing issues or background-launch behaviors associated with the standard SwiftUI WindowGroup lifecycle when launched as a Login Item.