### PR TITLE
Adding a help menu link to the official Live Stream Tally website

### DIFF
--- a/Sources/LiveStreamTally/LiveStreamTallyApp.swift
+++ b/Sources/LiveStreamTally/LiveStreamTallyApp.swift
@@ -118,6 +118,15 @@ struct LiveStreamTallyApp: App {
             }
             
             CommandGroup(replacing: .systemServices) {}  // Remove Services menu
+
+            // Replace the default Help menu item
+            CommandGroup(replacing: .help) {
+                Button("Live Stream Tally Help") {
+                    if let url = URL(string: "https://www.richardbolt.com/live-stream-tally/") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+            }
         }
         
         Settings {


### PR DESCRIPTION
Clicking the menu item directly links to the official site.